### PR TITLE
fix: use npx to launch chrome-devtools MCP

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -5,8 +5,8 @@
       "type": "local",
       "enabled": true,
       "command": [
-        "pnpm",
-        "dlx",
+        "npx",
+        "-y",
         "chrome-devtools-mcp@latest",
         "--headless=true",
         "--executablePath=/usr/bin/chromium",


### PR DESCRIPTION
## Summary
- replace `pnpm dlx` with `npx -y` in the `chrome-devtools` MCP command in `opencode.json`
- preserve all existing MCP/chromium flags while switching to a runner available in this environment
- unblock Chrome DevTools MCP startup in OpenCode

Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tool launcher configuration for improved execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->